### PR TITLE
Add support for JSON Output format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ repositories {
 
 dependencies {
     implementation 'uk.ac.gate:gate-core:8.6.1'
+    implementation 'uk.ac.gate.plugins:format-json:8.7'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-events:2.2.9'
 

--- a/src/test/java/co/zeroae/gate/AppTest.java
+++ b/src/test/java/co/zeroae/gate/AppTest.java
@@ -2,7 +2,8 @@ package co.zeroae.gate;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import org.junit.Before;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -56,5 +57,26 @@ public class AppTest {
         final TestContext context = new TestContext();
         final APIGatewayProxyResponseEvent result = app.handleRequest(input, context);
         assertEquals(result.getStatusCode().intValue(), 200);
+    }
+
+    @Test
+    public void testApplicationJsonResponse() throws Exception {
+        final HashMap<String, String> inputHeaders = new HashMap<>();
+        inputHeaders.put("Accept", "application/json");
+        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent()
+                .withHttpMethod("POST")
+                .withHeaders(Collections.unmodifiableMap(inputHeaders))
+                .withBody("My name is Lambda Function and I approve this test.");
+        final TestContext context = new TestContext();
+        final APIGatewayProxyResponseEvent result = app.handleRequest(input, context);
+        assertEquals(result.getStatusCode().intValue(), 200);
+
+        // Ensure we get back application/json back
+        assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(result.getBody());
+        while (!parser.isClosed()) {
+            parser.nextToken();
+        }
     }
 }


### PR DESCRIPTION
This PR lets the user export the results in either GateXML or [GateJSON][GateJSON] format.

The user can make this selection by setting the `Accept` header to either
  - GateXML:  `application/xml`
  - GateJSON: `application/json`

To maintain compatibility with our previous version, any value (or lack of) other than the ones above will default to GateXML format.

[GateJSON]: https://github.com/GateNLP/gateplugin-Format_JSON/blob/25d48ad054184e4a083c97eed4b30d1617361216/src/main/java/gate/corpora/export/GATEJsonExporter.java#L45