### PR TITLE
Output all annotations in JSON format

### DIFF
--- a/src/main/java/co/zeroae/gate/App.java
+++ b/src/main/java/co/zeroae/gate/App.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Objects;
 
 /**
@@ -71,9 +72,20 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
      * @param responseType One of the supported response types
      */
     private String encode(Document doc, String responseType) throws IOException {
+        final FeatureMap exportOptions = Factory.newFeatureMap();
+
+        // Take *all* annotation types.
+        final AnnotationSet defaultAnnots = doc.getAnnotations();
+        final HashSet<String> annotationTypes = new HashSet<>();
+        for (Annotation annotation: defaultAnnots.inDocumentOrder()) {
+            annotationTypes.add(annotation.getType());
+        }
+        exportOptions.put("annotationTypes", annotationTypes);
+
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         if (responseType.equals("application/json")) {
-            gateJsonExporter.export(doc, baos);
+            gateJsonExporter.setAnnotationTypes(doc.getAnnotationSetNames());
+            gateJsonExporter.export(doc, baos, exportOptions);
             return baos.toString();
         }
         else {

--- a/src/test/java/co/zeroae/gate/AppTest.java
+++ b/src/test/java/co/zeroae/gate/AppTest.java
@@ -66,7 +66,7 @@ public class AppTest {
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("POST")
                 .withHeaders(Collections.unmodifiableMap(inputHeaders))
-                .withBody("My name is Lambda Function and I approve this test.");
+                .withBody("Today is Monday.");
         final TestContext context = new TestContext();
         final APIGatewayProxyResponseEvent result = app.handleRequest(input, context);
         assertEquals(result.getStatusCode().intValue(), 200);


### PR DESCRIPTION
in #11 we added json export but did not give the user the option to select the annotation types.

Until that is available, we export all annotations.