### PR TITLE
Return 4xx on Exceptions

### DIFF
--- a/src/main/java/co/zeroae/gate/App.java
+++ b/src/main/java/co/zeroae/gate/App.java
@@ -54,9 +54,12 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
                 application.execute();
                 response.getHeaders().put("Content-Type", responseType);
                 return response.withBody(encode(doc, responseType)).withStatusCode(200);
-            } catch (ExecutionException | IOException e) {
+            } catch (ExecutionException e) {
                 logger.error(e);
-                return response.withBody(e.getMessage()).withStatusCode(500);
+                return response.withBody(e.getMessage()).withStatusCode(400);
+            } catch (IOException e) {
+                logger.error(e);
+                return response.withBody(e.getMessage()).withStatusCode(406);
             } finally {
                 corpus.clear();
                 Factory.deleteResource(doc);


### PR DESCRIPTION
What:
  Return 4xx errors when we get an exception from Gate or if we can't encode the response.

Why:
  Because 500 means it will be retried with the same values and cause it to fail again.