### PR TITLE
Add DiskLRU Based cache for Gate responses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'uk.ac.gate.plugins:format-json:8.7'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-events:2.2.9'
+    implementation 'com.jakewharton:disklrucache:2.0.2'
 
     runtimeOnly 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
 

--- a/src/main/java/co/zeroae/gate/App.java
+++ b/src/main/java/co/zeroae/gate/App.java
@@ -7,17 +7,21 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 
 import gate.*;
 import gate.corpora.export.GATEJsonExporter;
-import gate.creole.ExecutionException;
 import gate.creole.ResourceInstantiationException;
 import gate.util.GateException;
 import gate.util.persistence.PersistenceManager;
+
+import com.jakewharton.disklrucache.DiskLruCache;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+import org.codehaus.httpcache4j.util.Hex;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
+import javax.xml.stream.XMLStreamException;
+import java.io.*;
 import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Objects;
@@ -36,9 +40,17 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
         }
     }
 
+    private static final String GATE_APP_NAME = System.getenv("GATE_APP_NAME");
+    private static final String CACHE_DIR = System.getenv().getOrDefault(
+            "CACHE_DIR_PREFIX", "/tmp/lru/" + GATE_APP_NAME );
+    private static final double CACHE_DIR_USAGE = .9;
+
     private static final Logger logger = LogManager.getLogger(App.class);
     private static final CorpusController application = loadApplication();
     private static final GATEJsonExporter gateJsonExporter = new GATEJsonExporter();
+
+
+    private static final DiskLruCache cache = initializeCache();
 
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, final Context context) {
         final String responseType = input.getHeaders().getOrDefault("Accept", "application/xml");
@@ -47,27 +59,75 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
         response.getHeaders().put("Content-Type", "text/plain");
 
         try {
-            final Document doc = Factory.newDocument(input.getBody());
-            final Corpus corpus = application.getCorpus();
-            corpus.add(doc);
+            final String bodyDigest = computeMessageDigest(input.getBody());
+            response.getHeaders().put("x-zae-gate-cache", "HIT");
+            final Document doc = cacheComputeIfNull(
+                    bodyDigest,
+                    () -> {
+                        final Document rv = Factory.newDocument(input.getBody());
+                        final Corpus corpus = application.getCorpus();
+                        corpus.add(rv);
+                        try {
+                            application.execute();
+                        } finally {
+                            corpus.clear();
+                        }
+                        response.getHeaders().put("x-zae-gate-cache", "MISS");
+                        return rv;
+                    }
+            );
             try {
-                application.execute();
                 response.getHeaders().put("Content-Type", responseType);
                 return response.withBody(export(doc, responseType)).withStatusCode(200);
             } finally {
-                corpus.clear();
                 Factory.deleteResource(doc);
             }
-        } catch (ExecutionException e) {
+        } catch (GateException e) {
             logger.error(e);
             return response.withBody(e.getMessage()).withStatusCode(400);
         } catch (IOException e) {
             logger.error(e);
             return response.withBody(e.getMessage()).withStatusCode(406);
-        } catch (ResourceInstantiationException e) {
-            logger.warn(e);
-            return response.withBody(e.getMessage()).withStatusCode(400);
         }
+    }
+
+    private Document cacheComputeIfNull(String key, TextProcessor processor) throws GateException {
+        try {
+            final DiskLruCache.Snapshot snapshot = cache.get(key);
+            if (snapshot == null) {
+                final Document doc = processor.process();
+                try {
+                    DiskLruCache.Editor editor = cache.edit(key);
+                    editor.set(0, doc.toXml());
+                    editor.commit();
+                } catch (IOException e) {
+                    logger.warn(e);
+                }
+                return doc;
+            } else {
+                try {
+                    return Utils.xmlToDocument(new InputStreamReader(snapshot.getInputStream(0)));
+                } catch (ResourceInstantiationException | XMLStreamException e) {
+                    logger.warn(e);
+                    cache.remove(key);
+                    return processor.process();
+                }
+            }
+        } catch (IOException e) {
+            logger.warn(e);
+            return processor.process();
+        }
+    }
+
+    private String computeMessageDigest(String text) {
+        final String sha256;
+        try {
+            final MessageDigest md = MessageDigest.getInstance("SHA-256");
+            sha256 = Hex.encode(md.digest(text.getBytes()));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        return sha256;
     }
 
     /**
@@ -97,7 +157,7 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
 
     private static CorpusController loadApplication() {
         try {
-            final String gappResourcePah = System.getenv("GATE_APP_NAME") + "/application.xgapp";
+            final String gappResourcePah = GATE_APP_NAME + "/application.xgapp";
             final URL gappUrl = App.class.getClassLoader().getResource(gappResourcePah);
             final File gappFile = new File(Objects.requireNonNull(gappUrl).getFile());
             final CorpusController rv =
@@ -109,4 +169,26 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
             throw new RuntimeException(e);
         }
     }
+
+    private static DiskLruCache initializeCache() {
+        File cacheDir = new File(CACHE_DIR);
+        if (!cacheDir.exists() && !cacheDir.mkdirs()) {
+            throw new RuntimeException("Unable to create cache directory '" + cacheDir.getName() + "'.");
+        }
+        for (File file: Objects.requireNonNull(cacheDir.listFiles())) file.delete();
+        try {
+            long usableSpace = (long) (cacheDir.getUsableSpace()*CACHE_DIR_USAGE);
+            return DiskLruCache.open(cacheDir,
+                    1,
+                    1,
+                    usableSpace);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private interface TextProcessor {
+        Document process() throws GateException;
+    }
+
 }

--- a/src/main/java/co/zeroae/gate/Utils.java
+++ b/src/main/java/co/zeroae/gate/Utils.java
@@ -1,0 +1,32 @@
+package co.zeroae.gate;
+
+import gate.Document;
+import gate.Factory;
+import gate.creole.ResourceInstantiationException;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+public class Utils {
+    /**
+     *
+     * @param gateXMLReader
+     * @return
+     * @throws ResourceInstantiationException if Document
+     * @throws XMLStreamException
+     */
+    static Document xmlToDocument(Reader gateXMLReader) throws ResourceInstantiationException, XMLStreamException {
+        final Document doc = Factory.newDocument("");
+        XMLStreamReader reader;
+        reader = XMLInputFactory.newFactory().createXMLStreamReader(gateXMLReader);
+        do {
+            reader.next();
+        } while(reader.getEventType() != XMLStreamReader.START_ELEMENT);
+        gate.corpora.DocumentStaxUtils.readGateXmlDocument(reader, doc);
+        return doc;
+    }
+}


### PR DESCRIPTION
This PR adds [JakeWharton/DiskLruCache](https://github.com/JakeWharton/DiskLruCache) to ZeroAE's Gate Lambda call.

We populate the "x-zae-gate-cache" response header with `HIT` or `MISS` to indicate if the cache was used or not.

In case there are any exceptions while reading or writing to the cache, we abort the cache operation and revert to the standard behavior.

Currently, there is no way to disable the cache behavior.