### PR TITLE
Add AWS X-Ray tracing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,12 @@ repositories {
 dependencies {
     implementation 'uk.ac.gate:gate-core:8.6.1'
     implementation 'uk.ac.gate.plugins:format-json:8.7'
+
+    implementation platform('com.amazonaws:aws-xray-recorder-sdk-bom:2.4.0')
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-events:2.2.9'
+    implementation 'com.amazonaws:aws-xray-recorder-sdk-core'
+
     implementation 'com.jakewharton:disklrucache:2.0.2'
 
     runtimeOnly 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'

--- a/src/test/java/co/zeroae/gate/AppTest.java
+++ b/src/test/java/co/zeroae/gate/AppTest.java
@@ -2,9 +2,11 @@ package co.zeroae.gate;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.amazonaws.xray.AWSXRay;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import gate.Document;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -20,8 +22,10 @@ public class AppTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
+        AWSXRay.beginSegment("setUpClass");
         app = withEnvironmentVariable("GATE_APP_NAME", "annie")
                 .execute(App::new);
+        AWSXRay.endSegment();
     }
 
     private static App app = null;
@@ -29,10 +33,16 @@ public class AppTest {
 
     @Before
     public void setUp() {
+        AWSXRay.beginSegment("Test");
         input_headers = new HashMap<>();
         input = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("POST")
                 .withHeaders(input_headers);
+    }
+
+    @After
+    public void tearDown() {
+        AWSXRay.endSegment();
     }
     private APIGatewayProxyRequestEvent input = null;
     private HashMap<String, String> input_headers = null;


### PR DESCRIPTION
Instrumented code to support X-Ray Tracing. 
Here are the instrumentation points:

Gate Tracing:
  - Gate Init: The time it takes to call Gate.init()
  - Gate Load: The time it takes to load the Gate Application (Gazetteers, etc)
  - Gate Execute: The time it takes to execute the application on an individual document.
 
Cache Tracing:
  - Message Digest: The time it takes to compute the SHA256 sum.
  - Cache Edit: The time it takes to add a document to the cache.