### PR TITLE
Add more X-Ray instrumentation

### DIFF
--- a/src/main/java/co/zeroae/gate/Utils.java
+++ b/src/main/java/co/zeroae/gate/Utils.java
@@ -7,8 +7,6 @@ import gate.creole.ResourceInstantiationException;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
 
 public class Utils {


### PR DESCRIPTION
Added:
  - Gate Export: measures time it takes to convert Gate Document into the response output.
  - Cache Read: measures time to read the Gate Document from the cache.

Enhanced:
  - Message Digest: We add the SHA256 sum as part of the event metadata.

Removed:
  - Lambda handleRequest: Because it was redundant, AWS already creates this subsegment.