### PR TITLE
Pass annotationTypes in the FeatureMap for the DocumentExporter.

### DIFF
--- a/src/main/java/co/zeroae/gate/App.java
+++ b/src/main/java/co/zeroae/gate/App.java
@@ -236,8 +236,6 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
 
         // Take *all* annotation types and filter based on AnnotationSelector
         final AnnotationSet defaultAnnots = doc.getAnnotations();
-
-        // This if for GateJSONExporter (but should be for all exporters...)
         final Set<String> includeTypes = new HashSet<>(defaultAnnots.getAllTypes());
         if (annotationSelector != null)
             includeTypes.removeIf((type) -> !annotationSelector.contains(":" + type));


### PR DESCRIPTION
Exporting to XML or FastInfoset with *includeText=no* will honor the values of annotationTypes.

This gets us one step closer to removing the ugly hack of deleting the annotations from the document before export. 