### PR TITLE
Make Lambda Layers public

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -19,6 +19,13 @@ Resources:
       LicenseInfo: "Apache-2.0"
       RetentionPolicy: Retain
 
+  ZAERuntimeWrapperPublic:
+    Type: AWS::Lambda::LayerVersionPermission
+    Properties:
+      Action: lambda:GetLayerVersion
+      LayerVersionArn: !Ref ZAERuntimeWrapper
+      Principal: "*"
+
   ZAEGateLambdaLayer:
     Type: AWS::Serverless::LayerVersion
     Metadata:
@@ -34,6 +41,13 @@ Resources:
         - java8.al2
       LicenseInfo: 'AGPL-3.0'
       RetentionPolicy: Retain
+
+  ZAEGateLambdaPublic:
+    Type: AWS::Lambda::LayerVersionPermission
+    Properties:
+      Action: lambda:GetLayerVersion
+      LayerVersionArn: !Ref ZAEGateLambdaLayer
+      Principal: "*"
 
 Outputs:
   ZAERuntimeWrapper:


### PR DESCRIPTION
For lambda-java-gate starting with version `9`
```json
aws lambda get-layer-version-policy --layer-name zae-lambda-java-gate --version-number 9 --region=us-east-1 | jq .Policy -r |  jq
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "ZAEGateLambdaPublic-novAB5NlYLpr",
      "Effect": "Allow",
      "Principal": "*",
      "Action": "lambda:GetLayerVersion",
      "Resource": "arn:aws:lambda:us-east-1:162714053306:layer:zae-lambda-java-gate:9"
    }
  ]
}
```

For runtime, starting with version `1`
```json
aws lambda get-layer-version-policy --layer-name zae-lambda-runtime-wrapper --version-number 1 --region=us-east-1 | jq .Policy -r |  jq
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "ZAERuntimeWrapperPublic-mz8ysNySSZR2",
      "Effect": "Allow",
      "Principal": "*",
      "Action": "lambda:GetLayerVersion",
      "Resource": "arn:aws:lambda:us-east-1:162714053306:layer:zae-lambda-runtime-wrapper:1"
    }
  ]
}
```