### PR TITLE
GATE Cloud Client compatibility

### DIFF
--- a/examples/complete/http/test-annotations-query.http
+++ b/examples/complete/http/test-annotations-query.http
@@ -1,0 +1,38 @@
+### POST Single AnnotationRequest
+POST {{endpoint}}/{{name}}?annotations=:Token
+Content-Type: application/fastinfoset
+Accept: application/json
+
+< ./hello-world.finf
+> {%
+client.test("Request executed successfully", function() {
+  client.assert(response.body.entities.Token.length === 3, "Expected 3 tokens.");
+});
+%}
+
+
+### POST MultiValue AnnotationRequest
+POST {{endpoint}}/{{name}}?annotations=:Token&annotations=:Sentence
+Content-Type: application/fastinfoset
+Accept: application/json
+
+< ./hello-world.finf
+> {%
+client.test("Request executed successfully", function() {
+  client.assert(response.body.entities.Token.length === 3, "Expected 3 tokens.");
+  client.assert(response.body.entities.Sentence.length === 1, "Expected 1 sentence.");
+});
+%}
+
+### POST multi-valued comma separated annotations query
+POST {{endpoint}}/{{name}}?annotations=:Token, :Sentence
+Content-Type: application/fastinfoset
+Accept: application/json
+
+< ./hello-world.finf
+> {%
+client.test("Request executed successfully", function() {
+  client.assert(response.body.entities.Token.length === 3, "Expected 3 tokens.");
+  client.assert(response.body.entities.Sentence.length === 1, "Expected 1 sentence.");
+});
+%}

--- a/src/test/java/co/zeroae/gate/AppTest.java
+++ b/src/test/java/co/zeroae/gate/AppTest.java
@@ -105,11 +105,21 @@ public class AppTest {
         // Now we downselect to only one field.
         input.withMultiValueQueryStringParameters(new HashMap<>())
                 .getMultiValueQueryStringParameters()
-               .put("annotations", Collections.singletonList(":Token"));
+                .put("annotations", Collections.singletonList(":Token"));
         result = app.handleRequest(input, context);
 
         doc = Utils.xmlToDocument(new StringReader(result.getBody()));
         assertEquals(1, doc.getAnnotations().getAllTypes().size());
+
+        // Do the same but URL Encode the annotations query
+        input.withMultiValueQueryStringParameters(null)
+                .withQueryStringParameters(new HashMap<>())
+                .getQueryStringParameters()
+                .put("annotations", ":Token, :Sentence");
+        result = app.handleRequest(input, context);
+        doc = Utils.xmlToDocument(new StringReader(result.getBody()));
+        assertEquals(2, doc.getAnnotations().getAllTypes().size());
+
     }
 
     @Test

--- a/src/test/java/co/zeroae/gate/AppTest.java
+++ b/src/test/java/co/zeroae/gate/AppTest.java
@@ -111,7 +111,6 @@ public class AppTest {
         doc = Utils.xmlToDocument(new StringReader(result.getBody()));
         assertEquals(1, doc.getAnnotations().getAllTypes().size());
 
-        // Do the same but URL Encode the annotations query
         input.withMultiValueQueryStringParameters(null)
                 .withQueryStringParameters(new HashMap<>())
                 .getQueryStringParameters()


### PR DESCRIPTION
This PR ensures we can handle queries of the type `annotations=:Token, :Sentence` as well as `annotations=:Token&annotations=:Sentence`